### PR TITLE
Load part data for responses declines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='tap-wootric',
       install_requires=[
           'singer-python==5.9.0',
           'requests==2.20.0',
-          'backoff==1.9.2'
+          'backoff==1.8.0'
       ],
       entry_points='''
           [console_scripts]

--- a/tap_wootric/__init__.py
+++ b/tap_wootric/__init__.py
@@ -3,6 +3,7 @@
 import datetime
 import os
 from datetime import timezone
+import dateutil.relativedelta
 
 import backoff
 import requests
@@ -30,7 +31,7 @@ def load_schema(entity):
 
 
 def get_start(key):
-    if key not in STATE or key != "end_users":
+    if key not in STATE:
         return CONFIG['start_date']
 
     return STATE[key]
@@ -164,7 +165,13 @@ def gen_request(endpoint):
         if params[query_key_lt] > sync_start.timestamp():
             last_round = True
 
-    STATE[endpoint] = utils.strftime(sync_start)
+    STATE[endpoint] = generate_backfilled_date(endpoint, sync_start)
+
+def generate_backfilled_date(entity, dt):
+    if entity == "end_users":
+        return utils.strftime(dt)
+    else:
+        return utils.strftime(dt - dateutil.relativedelta.relativedelta(months=4))
 
 
 def transform_datetimes(row):

--- a/tests/testTapMethods.py
+++ b/tests/testTapMethods.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+from tap_wootric.__init__ import generate_backfilled_date
+from singer import utils
+
+
+class TestTapTransformingMethods():
+
+    def test_generate_backfilled_date_func(self):
+        sync_start = utils.strptime_to_utc("2021-11-06 16:30:00.32")
+        expected_date_for_responses = "2021-07-06T16:30:00.320000Z"
+        expected_date_for_end_users = "2021-11-06T16:30:00.320000Z"
+
+        generated_date_for_responses = generate_backfilled_date("responses", sync_start)
+        generated_date_for_end_users = generate_backfilled_date("end_users", sync_start)
+
+        assert generated_date_for_responses == expected_date_for_responses
+        assert generated_date_for_end_users == expected_date_for_end_users
+
+
+if __name__ == '__main__':
+    TestTapTransformingMethods().test_generate_backfilled_date_func()


### PR DESCRIPTION
# Description of change
(write a short description or paste a link to JIRA)
Added function for generating state date to have possibility to launch loading every day for last 4 months 

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
